### PR TITLE
Silence homebrew warnings.

### DIFF
--- a/swift-sh.rb
+++ b/swift-sh.rb
@@ -6,8 +6,8 @@ class SwiftSh < Formula
 
   bottle do
     root_url "https://github.com/mxcl/swift-sh/releases/download/2.2.0"
-    cellar :any_skip_relocation
-    sha256 "8bee3e8bcc0c3d9b05499c0b2e6622ef2200ed2f3c72707123261d47fd4d34d7" => :mojave
+    sha256 cellar: :any_skip_relocation
+    sha256 mojave: "8bee3e8bcc0c3d9b05499c0b2e6622ef2200ed2f3c72707123261d47fd4d34d7"
   end
 
   def install


### PR DESCRIPTION
This fixes the new warnings Homebrew is throwing, and seems consistent with fixes other packages have in the offing (without actually bothering to understand what Homebrew is complaining about).